### PR TITLE
Fixed loss-percentage

### DIFF
--- a/src/main/java/fr/skyost/skyowallet/extension/GoodbyeWallet.java
+++ b/src/main/java/fr/skyost/skyowallet/extension/GoodbyeWallet.java
@@ -59,8 +59,8 @@ public class GoodbyeWallet extends SkyowalletExtension {
 		final Player player = event.getEntity();
 		final SkyowalletAccountManager accountManager = getSkyowallet().getAccountManager();
 		if(!player.hasPermission("goodbyewallet.bypass") && accountManager.has(player)) {
-			final double amount = accountManager.get(player).getWallet().getAmount() * (1 - (config.lossPercentage / 100));
-			accountManager.get(player).getWallet().addAmount(amount, 0d);
+			final double amount = accountManager.get(player).getWallet().getAmount() * (config.lossPercentage / 100);
+			accountManager.get(player).getWallet().subtractAmount(amount, 0d);
 			players.add(player.getUniqueId());
 		}
 	}


### PR DESCRIPTION
It was subtracting the loss from 100% and adds the result to the balance instead of losing the percentage.
e.g. : Wallet: $100, Loss 30%
100% - 30% = 70%
Adds +70% to the balance when the player dies instead of losing 30%.
Wallet before the changes: 100 + 70 = $170
With this changes: 100 - 30 = $70